### PR TITLE
I didn't think you became a Scala hacker, Jeff :)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sc linguist-language=Scheme


### PR DESCRIPTION
GitHub guesses languages by using [Linguist](https://github.com/github/linguist) to crawl repos for file extensions. This showed up as 67.4% Scala and 1.8% SuperCollider due to `.sc` (I assume your compiler naming convention precluded the use of `.ss`). This one-liner fixes that.